### PR TITLE
Upgrade actions due to node 16 deperecation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         ref: ${{ inputs.ref }}
@@ -95,7 +95,7 @@ runs:
       shell: bash
 
     - name: Restore LFS cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: lfs-cache
       with:
         path: |


### PR DESCRIPTION
The checkout and cache actions v4 are both simply upgrades from node 16->20, with no other documented breaking changes. Sometime this year Node 16 will stop working in GHA. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/