### PR TITLE
Add SSH Key Param

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Cached LFS checkout"
+name: "Cached LFS checkout with SSH key support"
 
 description: "Git checkout with LFS files from cache"
 

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         ref: ${{ inputs.ref }}
@@ -106,13 +106,15 @@ runs:
       shell: bash
 
     - name: Restore LFS cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: lfs-cache
       with:
         path: |
           .git/lfs
           ${{ steps.cache-paths.outputs.CACHE_PATHS }}
         key: lfs-${{ hashFiles('.lfs-assets-id') }}-v2
+        restore-keys: |
+          lfs-
         enableCrossOsArchive: ${{ inputs.enableCrossOsArchive }}
 
     - name: Git LFS Pull

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,16 @@ inputs:
       [Learn more about cross-os caching](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cross-os-cache).
     required: false
     default: false
+  ssh-key:
+    description: >
+      SSH key used to fetch the repository. The SSH key is configured with the local
+      git config, which enables your scripts to run authenticated git commands. The
+      post-job step removes the SSH key.
+      
+      [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
+    required: false
+    default: ""
+
 
 runs:
   using: "composite"
@@ -71,6 +81,7 @@ runs:
         token: ${{ inputs.token }}
         submodules: ${{ inputs.submodules }}
         persist-credentials: ${{ inputs.persist-credentials }}
+        ssh-key: ${{ inputs.ssh-key }}
 
     - name: Create LFS file list
       run: |


### PR DESCRIPTION
This PR stemmed from [an issue I was running into](https://github.com/nschloe/action-cached-lfs-checkout/issues/38) with a private submodule - using the default GHA checkout, I needed to pass my ssh key in to be able to successfully check out my submodule. It was a pretty straightforward solution to get it working with this, just needed to set it up as an input and pass that to checkout!

Welcome to any feedback :)