### PR TITLE
Adding support for clean flag.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "Number of commits to fetch. 0 indicates all history for all tags and branches"
     required: false
     default: 1
+  clean:
+    description: "Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching"
+    required: false
+    default: true
   ref:
     description: >
       The branch, tag or SHA to checkout. When checking out the repository that
@@ -71,6 +75,7 @@ runs:
         token: ${{ inputs.token }}
         submodules: ${{ inputs.submodules }}
         persist-credentials: ${{ inputs.persist-credentials }}
+        clean: ${{ inputs.clean }}
 
     - name: Create LFS file list
       run: |


### PR DESCRIPTION
Currently this action uses actions/checkout@v4 which has support for a `clean` parameter which is not exposed in action-cached-lfs-checkout. This PR exposes the `clean` parameter so it can be used.

This is my first public project PR so please let me know if I missed some of the PR etiquette expectations.

